### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ test {
 
 application {
     mainClassName = "chatcat.gui.Launcher"
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 shadowJar {
@@ -58,4 +59,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/chatcat/commands/DeleteCommand.java
+++ b/src/main/java/chatcat/commands/DeleteCommand.java
@@ -37,6 +37,7 @@ public class DeleteCommand extends Command {
         String[] input = INDEX_TO_DELETE.split(" ");
         int toDelete = Integer.parseInt(input[1]) - 1;
 
+        assert toDelete < super.tasks.size() : "Index is larger than task list size";
         removed = tasks.remove(toDelete);
         writeToFile.toWrite(tasks);
     }

--- a/src/main/java/chatcat/commands/ExitCommand.java
+++ b/src/main/java/chatcat/commands/ExitCommand.java
@@ -1,4 +1,0 @@
-package chatcat.commands;
-
-public class ExitCommand {
-}

--- a/src/main/java/chatcat/commands/FilterCommand.java
+++ b/src/main/java/chatcat/commands/FilterCommand.java
@@ -31,7 +31,6 @@ public class FilterCommand extends Command {
      * Displays the tasks {@code Task} in tasklist {@code taskList} that includes a specified keyword.
      *
      * @see Task
-     * @see Commands
      */
     public void filter() throws ChatCatException {
         super.tasks = writeToFile.toRead();

--- a/src/main/java/chatcat/commands/ListTaskCommand.java
+++ b/src/main/java/chatcat/commands/ListTaskCommand.java
@@ -27,7 +27,6 @@ public class ListTaskCommand extends Command{
      *
      * @see WriteToFile
      * @see Task
-     * @see Commands
      */
     public void listTasks() {
         tasks = writeToFile.toRead();
@@ -42,15 +41,12 @@ public class ListTaskCommand extends Command{
     public String toString() {
         StringBuffer str = new StringBuffer();
 
-        if (tasks.size() == 0) {
-            str.append("empty list!");
-        } else {
-            str.append("Here are the tasks in your list:" + "\n");
-            for (int i = 0; i < super.tasks.size(); i++) {
-                str.append((i + 1) + ". " + super.tasks.get(i) + "\n");
-            }
+        assert super.tasks.size() > 0 : "empty list!";
+
+        str.append("Here are the tasks in your list:" + "\n");
+        for (int i = 0; i < super.tasks.size(); i++) {
+            str.append((i + 1) + ". " + super.tasks.get(i) + "\n");
         }
-        str.append("");
 
         return str.toString();
     }

--- a/src/main/java/chatcat/commands/MarkCommand.java
+++ b/src/main/java/chatcat/commands/MarkCommand.java
@@ -31,12 +31,12 @@ public class MarkCommand extends Command {
      *
      * @see Task
      * @see WriteToFile
-     * @see Commands
      */
     public void mark() {
         String[] input = MARK.split(" ");
         taskID = Integer.parseInt(input[1]) - 1;
 
+        assert taskID < super.tasks.size() : "Index is larger than task list size";
         super.tasks.get(taskID).setDone();
         super.writeToFile.toWrite(super.tasks);
     }

--- a/src/main/java/chatcat/commands/UnmarkCommand.java
+++ b/src/main/java/chatcat/commands/UnmarkCommand.java
@@ -36,6 +36,7 @@ public class UnmarkCommand extends Command {
         String[] input = UNMARK.split(" ");
         taskID = Integer.parseInt(input[1]) - 1;
 
+        assert taskID < super.tasks.size() : "Index is larger than task list size";
         super.tasks.get(taskID).setUndone();
         super.writeToFile.toWrite(super.tasks);
     }


### PR DESCRIPTION
Add assertions to ChatCat

Users are able to insert invalid inputs

Adding assertions would improve catching of invalid inputs placed by the
user

Assertions Added in,
* MarkCommand: index inserted by user has to be less than number of
tasks added
* UnmarkCommand: index inserted by user has to be less than number of
tasks added
* DeleteCommand: index inserted by user has to be less than number of
tasks added
* ListTaskCommand: list should not be empty